### PR TITLE
Minor Optimization Pass (Cached Properties)

### DIFF
--- a/Assets/Buildings/FreeOpenBuilding_1.1.2/FOB_1/Scripts/DoorMech.cs
+++ b/Assets/Buildings/FreeOpenBuilding_1.1.2/FOB_1/Scripts/DoorMech.cs
@@ -1,9 +1,11 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
+﻿using UnityEngine;
 
 public class DoorMech : MonoBehaviour 
 {
+    // Cached the transform. Using transform directly always
+    // uses GetComponent behind the scenes, so this script was
+    // taking up about 50% of the CPU time (at time of change) with the GetComponent call alone.
+    private Transform _transform; 
 
 	public Vector3 OpenRotation, CloseRotation;
 
@@ -16,22 +18,20 @@ public class DoorMech : MonoBehaviour
     public float interactionDistance = 3f;
     private Camera playerCamera;
 
-	void Start()
-	{
-		doorBool = false;
-		playerCamera = Camera.main;
-	}
+
+    private void Awake() {
+        _transform = transform;
+        playerCamera = Camera.main;
+
+        doorBool = false;        
+    }
 
 	void Update()
 	{
-		if (doorBool)
-		{
-			transform.rotation = Quaternion.Lerp(transform.rotation, Quaternion.Euler(OpenRotation), rotSpeed * Time.deltaTime);
-		}
-		else
-		{
-			transform.rotation = Quaternion.Lerp(transform.rotation, Quaternion.Euler(CloseRotation), rotSpeed * Time.deltaTime);	
-		}
+        Vector3 targetRotation = doorBool ? OpenRotation : CloseRotation;
+        if (_transform.rotation.eulerAngles != targetRotation) 
+        {
+            _transform.rotation = Quaternion.Lerp(_transform.rotation, Quaternion.Euler(targetRotation), rotSpeed * Time.deltaTime);
+        }
 	}
 }
-

--- a/Assets/Scenes/Game.unity
+++ b/Assets/Scenes/Game.unity
@@ -10848,7 +10848,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 40a34102b7a6eca48b073e4ab99ad8f1, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _playerObject: {fileID: 0}
+  _playerObject: {fileID: 1830504921}
 --- !u!1 &1851857602 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 4896059434030516683, guid: 2f9ac039a10be514dbfc03631d59a9c0, type: 3}

--- a/Assets/Scripts/UI/DebugInputManager.cs
+++ b/Assets/Scripts/UI/DebugInputManager.cs
@@ -3,25 +3,23 @@ using UnityEngine;
 public class DebugInputManager : MonoBehaviour
 {
     [SerializeField] private GameObject _playerObject;
+    private IHasHealth iHasHealth;
 
-    // Start is called once before the first execution of Update after the MonoBehaviour is created
-    void Start()
+    
+    void Awake()
     {
-        
+        iHasHealth = _playerObject.GetComponent<IHasHealth>();
     }
 
-    // Update is called once per frame
     void Update()
     {
         if (Input.GetKeyDown(KeyCode.RightBracket))
         {
-            var iHasHealth = _playerObject.GetComponent<IHasHealth>();
             iHasHealth.Heal(5f);
         }
         
         if (Input.GetKeyDown(KeyCode.LeftBracket))
         {
-            var iHasHealth = _playerObject.GetComponent<IHasHealth>();
             iHasHealth.TakeDamage(5f);
         }
     }

--- a/Assets/Scripts/UI/GamePlayHUD.cs
+++ b/Assets/Scripts/UI/GamePlayHUD.cs
@@ -1,29 +1,30 @@
 using TMPro;
 using UnityEngine;
-using UnityEngine.UI;
 
 public class GamePlayHUD : MonoBehaviour
-{
+{    
     public GameObject player;
-    public TextMeshProUGUI healthText; 
+    public TextMeshProUGUI healthText;
+    private PlayerStats playerStats;
 
     public SonNPC sonNPC;
     public TextMeshProUGUI sonHealthText;
 
+
     void Start()
     {
-        
+        playerStats = player.GetComponent<PlayerStats>();
     }
 
     // Update is called once per frame
     void Update()
     {
         if (player == null || healthText == null) return;
-        PlayerStats stats = player.GetComponent<PlayerStats>();
-        if (stats != null)
+        if (playerStats != null)
         {
-            healthText.text = "Health: " + stats.Health.ToString() + "/" + stats.MaxHealth.ToString();
+            healthText.text = "Health: " + playerStats.Health.ToString() + "/" + playerStats.MaxHealth.ToString();
         }
+
         if (sonNPC == null) return;
         sonHealthText.text = "Son Health: " + sonNPC.Health.ToString() + "/" + sonNPC.MaxHealth.ToString();
     }


### PR DESCRIPTION
I know premature optimization is frowned upon, but couldn't help notice some `GetComponent` calls in Update functions and thought this would be a good topic to cover. A useful Unity tip here, using `transform.` is the same as using `GetComponent<Transform>()`.

- Cached transform usage in DoorMech.cs 
- Simplified the rotation code and prevent unnecessary Lerping when the door reaches target rotations in DoorMech.cs
- PlayerStats usage cached in GamePlayHUD.cs
- IHasHealth usage cached in DebugInputManager.cs
- Player was re-assigned to the DebugInputManager component, can now debug change the player's health again

Before (check `Time ms` of DoorMech):
![doormech_update](https://github.com/user-attachments/assets/d49de959-170f-4bf9-bc7d-57ddbe3a2108)

After (check `Time ms` of DoorMech and Component.get_transform() is basically gone):
![doormech_update_cached](https://github.com/user-attachments/assets/e5db1ad5-67a9-48f5-b576-3f21f174d1a8)