### PR TITLE
Prevent Interaction Menu Spam

### DIFF
--- a/Assets/Scripts/Interactions/InteractionManager.cs
+++ b/Assets/Scripts/Interactions/InteractionManager.cs
@@ -27,6 +27,12 @@ public class InteractionManager : MonoBehaviour
 
     public void OpenMenu(List<string> interactions)
     {
+        // Check if the menu is already open to prevent repeated button spawning
+        if (_buttonPanel.activeInHierarchy) 
+        {
+            return;
+        }
+
         Cursor.lockState = CursorLockMode.None;
         Cursor.visible = true;
         


### PR DESCRIPTION
Just a quick check to see if the interaction menu is already open. This prevents spamming "E" key and Instantiating multiple copies of the interaction buttons.