### PR TITLE
Interaction Menu Dynamic Sizing

### DIFF
--- a/Assets/Scenes/Game.unity
+++ b/Assets/Scenes/Game.unity
@@ -10221,6 +10221,7 @@ GameObject:
   - component: {fileID: 1716465625}
   - component: {fileID: 1716465624}
   - component: {fileID: 1716465623}
+  - component: {fileID: 1716465626}
   m_Layer: 5
   m_Name: ButtonPanel
   m_TagString: Untagged
@@ -10245,7 +10246,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 200, y: 200}
+  m_SizeDelta: {x: 12, y: 12}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1716465623
 MonoBehaviour:
@@ -10260,12 +10261,12 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Padding:
-    m_Left: 0
-    m_Right: 0
-    m_Top: 0
-    m_Bottom: 0
+    m_Left: 6
+    m_Right: 6
+    m_Top: 6
+    m_Bottom: 6
   m_ChildAlignment: 4
-  m_Spacing: 5
+  m_Spacing: 6
   m_ChildForceExpandWidth: 1
   m_ChildForceExpandHeight: 0
   m_ChildControlWidth: 0
@@ -10311,6 +10312,20 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1716465621}
   m_CullTransparentMesh: 1
+--- !u!114 &1716465626
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1716465621}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3245ec927659c4140ac4f8d17403cc18, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_HorizontalFit: 2
+  m_VerticalFit: 2
 --- !u!1 &1744468987 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 3353174296399163480, guid: 2f9ac039a10be514dbfc03631d59a9c0, type: 3}

--- a/Assets/Scripts/Interactions/InteractionManager.cs
+++ b/Assets/Scripts/Interactions/InteractionManager.cs
@@ -49,21 +49,10 @@ public class InteractionManager : MonoBehaviour
                 buttonText.text = interaction.description;
             }
 
-            Button button = buttonObj.GetComponent<Button>();
-            if (button != null)
+            if (buttonObj.TryGetComponent<Button>(out var button))
             {
                 button.onClick.AddListener(() => OnInteractionClicked(interaction.key));
             }
-        }
-
-        // AI: Adjust the height of _buttonPanel to fit all buttons
-        RectTransform panelRectTransform = _buttonPanel.GetComponent<RectTransform>();
-        if (panelRectTransform != null)
-        {
-            float buttonHeight = _buttonPrefab.GetComponent<RectTransform>().sizeDelta.y;
-            float spacing = 10f; // Adjust spacing between buttons if needed
-            float totalHeight = interactions.Count * (buttonHeight + spacing) - spacing;
-            panelRectTransform.sizeDelta = new Vector2(panelRectTransform.sizeDelta.x, totalHeight);
         }
     }
 


### PR DESCRIPTION
Added a Content Size Fitter to the Interaction menu.
Now scales with Instantiated buttons without extra code. 
Also used Vertical Layout to add padding.

![menu](https://github.com/user-attachments/assets/b33312fc-b56d-401b-95d1-d5b263f97f62)