### PR TITLE
DebugHUD Null Ref Fix

### DIFF
--- a/Assets/Scripts/UI/DebugHUD.cs
+++ b/Assets/Scripts/UI/DebugHUD.cs
@@ -24,7 +24,6 @@ public class DebugHUD : MonoBehaviour
         if (enemyNPC)
         {
             enemyNPCHealth = enemyNPC.GetComponent<IHasHealth>();
-            return;
         }
     }
 

--- a/Assets/Scripts/UI/DebugHUD.cs
+++ b/Assets/Scripts/UI/DebugHUD.cs
@@ -9,7 +9,7 @@ public class DebugHUD : MonoBehaviour
     public TextMeshProUGUI groundedText;
     public TextMeshProUGUI sonNPCStateText;
     public TextMeshProUGUI sonNPCDistanceText;
-    public TextMeshProUGUI enemyHealthText; 
+    public TextMeshProUGUI enemyHealthText;
 
     // Objects of interest
     public CharacterController controller;
@@ -21,7 +21,11 @@ public class DebugHUD : MonoBehaviour
 
     void Start()
     {
-        enemyNPCHealth = enemyNPC.GetComponent<IHasHealth>();
+        if (enemyNPC)
+        {
+            enemyNPCHealth = enemyNPC.GetComponent<IHasHealth>();
+            return;
+        }
     }
 
     void Update()
@@ -39,7 +43,14 @@ public class DebugHUD : MonoBehaviour
             sonNPCStateText.text = "SonNPC State: " + sonNPC.StateMachine.CurrentState?.GetType().Name;
             float distance = Vector3.Distance(controller.transform.position, sonNPC.transform.position);
             sonNPCDistanceText.text = "SonNPC Dist: " + distance.ToString("F2");
-            enemyHealthText.text = "Enemy Health: " + enemyNPCHealth.Health.ToString("F2");
+
+            // As we now have multiple enemies, we should either extend the DebugHUD to support multiple enemies
+            // Or simply remove the enemy health display if not needed
+            // This object check prevents null reference exceptions when we don't have an enemy assigned
+            if (enemyNPC != null && enemyNPCHealth != null)
+            {
+                enemyHealthText.text = "Enemy Health: " + enemyNPCHealth.Health.ToString("F2");
+            }
         }
     }
 }


### PR DESCRIPTION
We had a null ref error spamming the console due to the EnemyNPC not being assigned to the DebugHUD.

Now that we have multiple enemies, we should either extend the DebugHUD to support this or just not include enemies.