### PR TITLE
NPC Debug Canvas

### DIFF
--- a/Assets/Prefabs/FriendlyChildNPC.prefab
+++ b/Assets/Prefabs/FriendlyChildNPC.prefab
@@ -14,9 +14,12 @@ GameObject:
   - component: {fileID: 451806012176524068}
   - component: {fileID: 3756950185822581458}
   - component: {fileID: 6891348782625597385}
-  m_Layer: 0
+  - component: {fileID: 2479616268200902174}
+  - component: {fileID: 3579123722393013533}
+  - component: {fileID: 7532216839783929934}
+  m_Layer: 7
   m_Name: FriendlyChildNPC
-  m_TagString: Untagged
+  m_TagString: FriendlyNPC
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -31,10 +34,12 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 123.31, y: 1.8, z: 136.07}
-  m_LocalScale: {x: 1, y: 1.8, z: 1}
+  m_LocalScale: {x: 0.65, y: 1.1, z: 0.65}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 5018972938337270409}
+  - {fileID: 1113031309581695644}
+  - {fileID: 8737025671680567257}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &709175182522422886
@@ -68,7 +73,7 @@ MeshRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
+  - {fileID: 2100000, guid: cc62858f928532245b1b0434a2daf2a8, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -107,7 +112,7 @@ CapsuleCollider:
   m_LayerOverridePriority: 0
   m_IsTrigger: 0
   m_ProvidesContacts: 0
-  m_Enabled: 1
+  m_Enabled: 0
   serializedVersion: 2
   m_Radius: 0.5
   m_Height: 2
@@ -144,7 +149,7 @@ Rigidbody:
   m_GameObject: {fileID: 1360472216782407304}
   serializedVersion: 4
   m_Mass: 1
-  m_Drag: 0
+  m_Drag: 1
   m_AngularDrag: 0.05
   m_CenterOfMass: {x: 0, y: 0, z: 0}
   m_InertiaTensor: {x: 1, y: 1, z: 1}
@@ -161,7 +166,87 @@ Rigidbody:
   m_IsKinematic: 0
   m_Interpolate: 0
   m_Constraints: 0
-  m_CollisionDetection: 0
+  m_CollisionDetection: 1
+--- !u!136 &2479616268200902174
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1360472216782407304}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5
+  m_Height: 2
+  m_Direction: 1
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!114 &3579123722393013533
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1360472216782407304}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d7fe1494ead26de4396127076aaff28f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _audioSource: {fileID: 0}
+  _entityProfile:
+    _personality:
+      Trusting: 0.69
+      Loving: 0.74
+      Courage: 0.05
+      Decisiveness: 0.16
+      Composure: -0.16
+    _mentalState:
+      Comfort: 0.3
+      BaseComfortRate: 0.1
+      Calmness: 0
+      BaseCalmRate: 0.1
+  rotationSpeed: 90
+  moveSpeed: 5.5
+  detectionDistance: 15.5
+  stopDistance: 3.5
+  _health: 100
+  _maxHealth: 100
+  HealthSlider: {fileID: 2745997524974623513}
+  DistanceText: {fileID: 6664039980277979374}
+  target: {fileID: 0}
+  menu: {fileID: 0}
+--- !u!95 &7532216839783929934
+Animator:
+  serializedVersion: 7
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1360472216782407304}
+  m_Enabled: 1
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 9100000, guid: 29d7a77411deb4de8ac7805cc522c2e3, type: 2}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
+  m_AnimatePhysics: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorStateOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 0
 --- !u!1 &1614400826536179606
 GameObject:
   m_ObjectHideFlags: 0
@@ -172,13 +257,13 @@ GameObject:
   m_Component:
   - component: {fileID: 5018972938337270409}
   - component: {fileID: 2066647357086029142}
-  m_Layer: 0
+  m_Layer: 7
   m_Name: ForwardMarker
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &5018972938337270409
 Transform:
   m_ObjectHideFlags: 0
@@ -188,8 +273,8 @@ Transform:
   m_GameObject: {fileID: 1614400826536179606}
   serializedVersion: 2
   m_LocalRotation: {x: -0.07590101, y: 0.017197754, z: 0.048194252, w: 0.9958015}
-  m_LocalPosition: {x: -0.077, y: 0.584, z: 0.495}
-  m_LocalScale: {x: 0.10000249, y: 0.09999765, z: 0.100001596}
+  m_LocalPosition: {x: 0.715, y: 0.604, z: 1.041}
+  m_LocalScale: {x: 0, y: 9, z: 9}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2560983965479213082}
@@ -217,7 +302,7 @@ SpriteRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 2100000, guid: 9dfc825aed78fcd4ba02077103263b40, type: 2}
+  - {fileID: 2100000, guid: 384d1b374094f409b955f15ee53b040a, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -239,7 +324,7 @@ SpriteRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: d50a9c185c4ed884db830c0c45504554, type: 3}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Color: {r: 0, g: 0, b: 0, a: 1}
   m_FlipX: 0
   m_FlipY: 0
   m_DrawMode: 0
@@ -249,3 +334,243 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!1 &2278582911275438558
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1113031309581695644}
+  - component: {fileID: 5854702563450333409}
+  - component: {fileID: 6713030986210410238}
+  - component: {fileID: 3671755052789290715}
+  m_Layer: 7
+  m_Name: ForwardMarker2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1113031309581695644
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2278582911275438558}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.29, y: 0.588, z: 0}
+  m_LocalScale: {x: 0.5, y: 0.5, z: 0.5}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2560983965479213082}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &5854702563450333409
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2278582911275438558}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &6713030986210410238
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2278582911275438558}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 384d1b374094f409b955f15ee53b040a, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!135 &3671755052789290715
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2278582911275438558}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!1001 &6289027614045258726
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 2560983965479213082}
+    m_Modifications:
+    - target: {fileID: 3316685370362913855, guid: d4b577630be655049bbaf5ac70b94f51, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3316685370362913855, guid: d4b577630be655049bbaf5ac70b94f51, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3316685370362913855, guid: d4b577630be655049bbaf5ac70b94f51, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3316685370362913855, guid: d4b577630be655049bbaf5ac70b94f51, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3316685370362913855, guid: d4b577630be655049bbaf5ac70b94f51, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3316685370362913855, guid: d4b577630be655049bbaf5ac70b94f51, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3316685370362913855, guid: d4b577630be655049bbaf5ac70b94f51, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 200
+      objectReference: {fileID: 0}
+    - target: {fileID: 3316685370362913855, guid: d4b577630be655049bbaf5ac70b94f51, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 50
+      objectReference: {fileID: 0}
+    - target: {fileID: 3316685370362913855, guid: d4b577630be655049bbaf5ac70b94f51, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3316685370362913855, guid: d4b577630be655049bbaf5ac70b94f51, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3316685370362913855, guid: d4b577630be655049bbaf5ac70b94f51, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3316685370362913855, guid: d4b577630be655049bbaf5ac70b94f51, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3316685370362913855, guid: d4b577630be655049bbaf5ac70b94f51, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3316685370362913855, guid: d4b577630be655049bbaf5ac70b94f51, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3316685370362913855, guid: d4b577630be655049bbaf5ac70b94f51, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3316685370362913855, guid: d4b577630be655049bbaf5ac70b94f51, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3316685370362913855, guid: d4b577630be655049bbaf5ac70b94f51, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 1.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 3316685370362913855, guid: d4b577630be655049bbaf5ac70b94f51, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3316685370362913855, guid: d4b577630be655049bbaf5ac70b94f51, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3316685370362913855, guid: d4b577630be655049bbaf5ac70b94f51, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4935543959334225805, guid: d4b577630be655049bbaf5ac70b94f51, type: 3}
+      propertyPath: m_Name
+      value: HealthSliderCanvas
+      objectReference: {fileID: 0}
+    - target: {fileID: 9022831795014189244, guid: d4b577630be655049bbaf5ac70b94f51, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9022831795014189244, guid: d4b577630be655049bbaf5ac70b94f51, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d4b577630be655049bbaf5ac70b94f51, type: 3}
+--- !u!114 &2745997524974623513 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8168583561612138751, guid: d4b577630be655049bbaf5ac70b94f51, type: 3}
+  m_PrefabInstance: {fileID: 6289027614045258726}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &6664039980277979374 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 809645481733004040, guid: d4b577630be655049bbaf5ac70b94f51, type: 3}
+  m_PrefabInstance: {fileID: 6289027614045258726}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!224 &8737025671680567257 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 3316685370362913855, guid: d4b577630be655049bbaf5ac70b94f51, type: 3}
+  m_PrefabInstance: {fileID: 6289027614045258726}
+  m_PrefabAsset: {fileID: 0}

--- a/Assets/Prefabs/FriendlyChildNPC.prefab
+++ b/Assets/Prefabs/FriendlyChildNPC.prefab
@@ -221,8 +221,6 @@ MonoBehaviour:
   stopDistance: 3.5
   _health: 100
   _maxHealth: 100
-  HealthSlider: {fileID: 2745997524974623513}
-  DistanceText: {fileID: 6664039980277979374}
   target: {fileID: 0}
   menu: {fileID: 0}
 --- !u!95 &7532216839783929934
@@ -450,6 +448,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 2560983965479213082}
     m_Modifications:
+    - target: {fileID: 2466390616220768613, guid: d4b577630be655049bbaf5ac70b94f51, type: 3}
+      propertyPath: NPC
+      value: 
+      objectReference: {fileID: 3579123722393013533}
     - target: {fileID: 3316685370362913855, guid: d4b577630be655049bbaf5ac70b94f51, type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
@@ -547,28 +549,6 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d4b577630be655049bbaf5ac70b94f51, type: 3}
---- !u!114 &2745997524974623513 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 8168583561612138751, guid: d4b577630be655049bbaf5ac70b94f51, type: 3}
-  m_PrefabInstance: {fileID: 6289027614045258726}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &6664039980277979374 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 809645481733004040, guid: d4b577630be655049bbaf5ac70b94f51, type: 3}
-  m_PrefabInstance: {fileID: 6289027614045258726}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!224 &8737025671680567257 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 3316685370362913855, guid: d4b577630be655049bbaf5ac70b94f51, type: 3}

--- a/Assets/Prefabs/NPCPatrolman.prefab
+++ b/Assets/Prefabs/NPCPatrolman.prefab
@@ -490,8 +490,6 @@ MonoBehaviour:
   stopDistance: 5
   _health: 100
   _maxHealth: 100
-  HealthSlider: {fileID: 9194204530685957809}
-  DistanceText: {fileID: 430291058108945734}
   target: {fileID: 0}
   _defaultState: EnemyIdle
   PatrolPoints: []
@@ -646,10 +644,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 5311034482893019840}
     m_Modifications:
-    - target: {fileID: 1358857095831013244, guid: d4b577630be655049bbaf5ac70b94f51, type: 3}
-      propertyPath: m_PresetInfoIsWorld
-      value: 1
-      objectReference: {fileID: 0}
+    - target: {fileID: 2466390616220768613, guid: d4b577630be655049bbaf5ac70b94f51, type: 3}
+      propertyPath: NPC
+      value: 
+      objectReference: {fileID: 4174098608106142634}
     - target: {fileID: 3316685370362913855, guid: d4b577630be655049bbaf5ac70b94f51, type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
@@ -734,43 +732,13 @@ PrefabInstance:
       propertyPath: m_Name
       value: HealthSliderCanvas
       objectReference: {fileID: 0}
-    - target: {fileID: 9022831795014189244, guid: d4b577630be655049bbaf5ac70b94f51, type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9022831795014189244, guid: d4b577630be655049bbaf5ac70b94f51, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d4b577630be655049bbaf5ac70b94f51, type: 3}
---- !u!114 &430291058108945734 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 809645481733004040, guid: d4b577630be655049bbaf5ac70b94f51, type: 3}
-  m_PrefabInstance: {fileID: 1064190051349319246}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!224 &2361004353107077745 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 3316685370362913855, guid: d4b577630be655049bbaf5ac70b94f51, type: 3}
   m_PrefabInstance: {fileID: 1064190051349319246}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &9194204530685957809 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 8168583561612138751, guid: d4b577630be655049bbaf5ac70b94f51, type: 3}
-  m_PrefabInstance: {fileID: 1064190051349319246}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 

--- a/Assets/Prefabs/NPCPatrolman.prefab
+++ b/Assets/Prefabs/NPCPatrolman.prefab
@@ -127,6 +127,7 @@ Transform:
   - {fileID: 1436593958396780205}
   - {fileID: 2993936329990231063}
   - {fileID: 5337429917959413788}
+  - {fileID: 2361004353107077745}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &4082979276276837038
@@ -250,7 +251,7 @@ Rigidbody:
   m_ImplicitCom: 1
   m_ImplicitTensor: 1
   m_UseGravity: 1
-  m_IsKinematic: 0
+  m_IsKinematic: 1
   m_Interpolate: 0
   m_Constraints: 0
   m_CollisionDetection: 0
@@ -485,10 +486,12 @@ MonoBehaviour:
       BaseCalmRate: 0.1
   rotationSpeed: 90
   moveSpeed: 3.5
-  detectionDistance: 5
-  stopDistance: 1
+  detectionDistance: 10
+  stopDistance: 5
   _health: 100
   _maxHealth: 100
+  HealthSlider: {fileID: 9194204530685957809}
+  DistanceText: {fileID: 430291058108945734}
   target: {fileID: 0}
   _defaultState: EnemyIdle
   PatrolPoints: []
@@ -635,3 +638,139 @@ SphereCollider:
   serializedVersion: 3
   m_Radius: 0.5
   m_Center: {x: 0, y: 0, z: 0}
+--- !u!1001 &1064190051349319246
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 5311034482893019840}
+    m_Modifications:
+    - target: {fileID: 1358857095831013244, guid: d4b577630be655049bbaf5ac70b94f51, type: 3}
+      propertyPath: m_PresetInfoIsWorld
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3316685370362913855, guid: d4b577630be655049bbaf5ac70b94f51, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3316685370362913855, guid: d4b577630be655049bbaf5ac70b94f51, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3316685370362913855, guid: d4b577630be655049bbaf5ac70b94f51, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3316685370362913855, guid: d4b577630be655049bbaf5ac70b94f51, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3316685370362913855, guid: d4b577630be655049bbaf5ac70b94f51, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3316685370362913855, guid: d4b577630be655049bbaf5ac70b94f51, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3316685370362913855, guid: d4b577630be655049bbaf5ac70b94f51, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 200
+      objectReference: {fileID: 0}
+    - target: {fileID: 3316685370362913855, guid: d4b577630be655049bbaf5ac70b94f51, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 50
+      objectReference: {fileID: 0}
+    - target: {fileID: 3316685370362913855, guid: d4b577630be655049bbaf5ac70b94f51, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3316685370362913855, guid: d4b577630be655049bbaf5ac70b94f51, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3316685370362913855, guid: d4b577630be655049bbaf5ac70b94f51, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3316685370362913855, guid: d4b577630be655049bbaf5ac70b94f51, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3316685370362913855, guid: d4b577630be655049bbaf5ac70b94f51, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3316685370362913855, guid: d4b577630be655049bbaf5ac70b94f51, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3316685370362913855, guid: d4b577630be655049bbaf5ac70b94f51, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3316685370362913855, guid: d4b577630be655049bbaf5ac70b94f51, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3316685370362913855, guid: d4b577630be655049bbaf5ac70b94f51, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 1.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 3316685370362913855, guid: d4b577630be655049bbaf5ac70b94f51, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3316685370362913855, guid: d4b577630be655049bbaf5ac70b94f51, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3316685370362913855, guid: d4b577630be655049bbaf5ac70b94f51, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4935543959334225805, guid: d4b577630be655049bbaf5ac70b94f51, type: 3}
+      propertyPath: m_Name
+      value: HealthSliderCanvas
+      objectReference: {fileID: 0}
+    - target: {fileID: 9022831795014189244, guid: d4b577630be655049bbaf5ac70b94f51, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9022831795014189244, guid: d4b577630be655049bbaf5ac70b94f51, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d4b577630be655049bbaf5ac70b94f51, type: 3}
+--- !u!114 &430291058108945734 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 809645481733004040, guid: d4b577630be655049bbaf5ac70b94f51, type: 3}
+  m_PrefabInstance: {fileID: 1064190051349319246}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!224 &2361004353107077745 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 3316685370362913855, guid: d4b577630be655049bbaf5ac70b94f51, type: 3}
+  m_PrefabInstance: {fileID: 1064190051349319246}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &9194204530685957809 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8168583561612138751, guid: d4b577630be655049bbaf5ac70b94f51, type: 3}
+  m_PrefabInstance: {fileID: 1064190051349319246}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Scripts/CommonNPC/BaseNPC.cs
+++ b/Assets/Scripts/CommonNPC/BaseNPC.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections;
-using TMPro;
 using UnityEngine;
-using UnityEngine.UI;
 
 public class BaseNPC : MonoBehaviour, IHasHealth
 {
@@ -57,12 +55,7 @@ public class BaseNPC : MonoBehaviour, IHasHealth
     {
         get => _maxHealth;
         set => _maxHealth = value;
-    }
-
-    [Header("Debug Health Slider")]
-    private Transform _playerTransform;
-    public Slider HealthSlider;
-    public TextMeshProUGUI DistanceText;
+    }    
 
     public Transform target;
 
@@ -76,8 +69,6 @@ public class BaseNPC : MonoBehaviour, IHasHealth
     public float TakeDamage(float damage)
     {
         Health -= damage;
-        UpdateHealthSlider();
-
         if (Health < 0) Health = 0;
         this.OnHealthChanged?.Invoke(Health);
         if (Health <= 0)
@@ -101,8 +92,6 @@ public class BaseNPC : MonoBehaviour, IHasHealth
     float IHasHealth.Heal(float amount)
     {
         Health += amount;
-        UpdateHealthSlider();
-
         if (Health > MaxHealth) Health = MaxHealth;
         this.OnHealthChanged?.Invoke(Health);
         return Health;
@@ -115,9 +104,6 @@ public class BaseNPC : MonoBehaviour, IHasHealth
     {
         _animator = GetComponent<Animator>();
         _audioSource = GetComponent<AudioSource>();
-        _playerTransform = GameObject.FindGameObjectWithTag("Player").transform; // I don't like this
-
-        SetUpHealthSlider();
     }
 
     public void Panic()
@@ -146,31 +132,5 @@ public class BaseNPC : MonoBehaviour, IHasHealth
         if (stateMachine == null) return;
         stateMachine.Update();
     }
-
-    private void LateUpdate()
-    {
-        if (DistanceText != null)
-        {
-            float distance = Vector3.Distance(transform.position, _playerTransform.position);
-            DistanceText.text = $"{distance:F2} m";
-        }
-    }
-
-    private void SetUpHealthSlider()
-    {
-        if (HealthSlider == null)
-        {
-            Debug.LogError("HealthSlider not assigned on NPC: " + name);
-            return;
-        }
-
-        HealthSlider.minValue = 0;
-        HealthSlider.maxValue = MaxHealth;
-        HealthSlider.value = Health;
-    }
-
-    private void UpdateHealthSlider()
-    {
-        HealthSlider.value = Health;
-    }
+    
 }

--- a/Assets/Scripts/CommonNPC/BaseNPC.cs
+++ b/Assets/Scripts/CommonNPC/BaseNPC.cs
@@ -1,6 +1,8 @@
-using UnityEngine;
 using System;
 using System.Collections;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
 
 public class BaseNPC : MonoBehaviour, IHasHealth
 {
@@ -57,6 +59,11 @@ public class BaseNPC : MonoBehaviour, IHasHealth
         set => _maxHealth = value;
     }
 
+    [Header("Debug Health Slider")]
+    private Transform _playerTransform;
+    public Slider HealthSlider;
+    public TextMeshProUGUI DistanceText;
+
     public Transform target;
 
     public void setState(NPCState state)
@@ -69,6 +76,8 @@ public class BaseNPC : MonoBehaviour, IHasHealth
     public float TakeDamage(float damage)
     {
         Health -= damage;
+        UpdateHealthSlider();
+
         if (Health < 0) Health = 0;
         this.OnHealthChanged?.Invoke(Health);
         if (Health <= 0)
@@ -92,6 +101,8 @@ public class BaseNPC : MonoBehaviour, IHasHealth
     float IHasHealth.Heal(float amount)
     {
         Health += amount;
+        UpdateHealthSlider();
+
         if (Health > MaxHealth) Health = MaxHealth;
         this.OnHealthChanged?.Invoke(Health);
         return Health;
@@ -104,6 +115,9 @@ public class BaseNPC : MonoBehaviour, IHasHealth
     {
         _animator = GetComponent<Animator>();
         _audioSource = GetComponent<AudioSource>();
+        _playerTransform = GameObject.FindGameObjectWithTag("Player").transform; // I don't like this
+
+        SetUpHealthSlider();
     }
 
     public void Panic()
@@ -131,5 +145,32 @@ public class BaseNPC : MonoBehaviour, IHasHealth
     {
         if (stateMachine == null) return;
         stateMachine.Update();
+    }
+
+    private void LateUpdate()
+    {
+        if (DistanceText != null)
+        {
+            float distance = Vector3.Distance(transform.position, _playerTransform.position);
+            DistanceText.text = $"{distance:F2} m";
+        }
+    }
+
+    private void SetUpHealthSlider()
+    {
+        if (HealthSlider == null)
+        {
+            Debug.LogError("HealthSlider not assigned on NPC: " + name);
+            return;
+        }
+
+        HealthSlider.minValue = 0;
+        HealthSlider.maxValue = MaxHealth;
+        HealthSlider.value = Health;
+    }
+
+    private void UpdateHealthSlider()
+    {
+        HealthSlider.value = Health;
     }
 }

--- a/Assets/_Game/UI/NPCDebugCanvas.prefab
+++ b/Assets/_Game/UI/NPCDebugCanvas.prefab
@@ -242,7 +242,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 10, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1133680853822691359
 CanvasRenderer:
@@ -315,8 +315,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0.25}
   m_AnchorMax: {x: 1, y: 0.75}
-  m_AnchoredPosition: {x: -5, y: 0}
-  m_SizeDelta: {x: -20, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &8488268522040989965
 GameObject:
@@ -441,9 +441,9 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 24}
-  m_SizeDelta: {x: 256, y: 40}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 8}
+  m_SizeDelta: {x: 256, y: 100}
+  m_Pivot: {x: 0.5, y: 0}
 --- !u!222 &694778107394541304
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -507,7 +507,7 @@ MonoBehaviour:
   m_fontSizeMax: 72
   m_fontStyle: 0
   m_HorizontalAlignment: 2
-  m_VerticalAlignment: 512
+  m_VerticalAlignment: 1024
   m_textAlignment: 65535
   m_characterSpacing: 0
   m_wordSpacing: 0

--- a/Assets/_Game/UI/NPCDebugCanvas.prefab
+++ b/Assets/_Game/UI/NPCDebugCanvas.prefab
@@ -88,6 +88,7 @@ GameObject:
   - component: {fileID: 1358857095831013244}
   - component: {fileID: 1230757540074980299}
   - component: {fileID: 5306263897499878715}
+  - component: {fileID: 2466390616220768613}
   m_Layer: 5
   m_Name: NPCDebugCanvas
   m_TagString: Untagged
@@ -161,7 +162,7 @@ MonoBehaviour:
   m_FallbackScreenDPI: 96
   m_DefaultSpriteDPI: 96
   m_DynamicPixelsPerUnit: 1
-  m_PresetInfoIsWorld: 0
+  m_PresetInfoIsWorld: 1
 --- !u!114 &1230757540074980299
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -191,6 +192,21 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 09e33b8653ff0784a9feea12b4b9922f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &2466390616220768613
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4935543959334225805}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c9452cfa57cd6234c863bb57c0325fc6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  NPC: {fileID: 0}
+  HealthSlider: {fileID: 8168583561612138751}
+  DistanceText: {fileID: 809645481733004040}
 --- !u!1 &5126470157439293578
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/_Game/UI/NPCDebugCanvas.prefab
+++ b/Assets/_Game/UI/NPCDebugCanvas.prefab
@@ -1,0 +1,529 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1278442823804832940
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1748750009875851417}
+  - component: {fileID: 1965628907285839275}
+  - component: {fileID: 1410140238775146376}
+  m_Layer: 5
+  m_Name: Background
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1748750009875851417
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1278442823804832940}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5577490129741727444}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.25}
+  m_AnchorMax: {x: 1, y: 0.75}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1965628907285839275
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1278442823804832940}
+  m_CullTransparentMesh: 1
+--- !u!114 &1410140238775146376
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1278442823804832940}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 0.5019608}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &4935543959334225805
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3316685370362913855}
+  - component: {fileID: 2485587487239064795}
+  - component: {fileID: 1358857095831013244}
+  - component: {fileID: 1230757540074980299}
+  - component: {fileID: 5306263897499878715}
+  m_Layer: 5
+  m_Name: NPCDebugCanvas
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3316685370362913855
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4935543959334225805}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.01, y: 0.01, z: 0.01}
+  m_ConstrainProportionsScale: 1
+  m_Children:
+  - {fileID: 5577490129741727444}
+  - {fileID: 5370022722292042738}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 1.199997}
+  m_SizeDelta: {x: 200, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!223 &2485587487239064795
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4935543959334225805}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 2
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_VertexColorAlwaysGammaSpace: 0
+  m_AdditionalShaderChannelsFlag: 25
+  m_UpdateRectTransformForStandalone: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!114 &1358857095831013244
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4935543959334225805}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 1
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 1920, y: 1080}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0.5
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 0
+--- !u!114 &1230757540074980299
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4935543959334225805}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!114 &5306263897499878715
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4935543959334225805}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 09e33b8653ff0784a9feea12b4b9922f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &5126470157439293578
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 9022831795014189244}
+  - component: {fileID: 1133680853822691359}
+  - component: {fileID: 2551060700551840784}
+  m_Layer: 5
+  m_Name: Fill
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &9022831795014189244
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5126470157439293578}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1396294176799217668}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 10, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1133680853822691359
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5126470157439293578}
+  m_CullTransparentMesh: 1
+--- !u!114 &2551060700551840784
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5126470157439293578}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &5214160799373448778
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1396294176799217668}
+  m_Layer: 5
+  m_Name: Fill Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1396294176799217668
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5214160799373448778}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 9022831795014189244}
+  m_Father: {fileID: 5577490129741727444}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.25}
+  m_AnchorMax: {x: 1, y: 0.75}
+  m_AnchoredPosition: {x: -5, y: 0}
+  m_SizeDelta: {x: -20, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &8488268522040989965
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5577490129741727444}
+  - component: {fileID: 8168583561612138751}
+  m_Layer: 5
+  m_Name: HealthSlider
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5577490129741727444
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8488268522040989965}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1748750009875851417}
+  - {fileID: 1396294176799217668}
+  m_Father: {fileID: 3316685370362913855}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 160, y: 30}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &8168583561612138751
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8488268522040989965}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 0.2478261, g: 0.75, b: 0, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 2551060700551840784}
+  m_FillRect: {fileID: 9022831795014189244}
+  m_HandleRect: {fileID: 0}
+  m_Direction: 0
+  m_MinValue: 0
+  m_MaxValue: 100
+  m_WholeNumbers: 0
+  m_Value: 62.3
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!1 &8571580769371823078
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5370022722292042738}
+  - component: {fileID: 694778107394541304}
+  - component: {fileID: 809645481733004040}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5370022722292042738
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8571580769371823078}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3316685370362913855}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 24}
+  m_SizeDelta: {x: 256, y: 40}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &694778107394541304
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8571580769371823078}
+  m_CullTransparentMesh: 1
+--- !u!114 &809645481733004040
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8571580769371823078}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 12.62 m
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 34
+  m_fontSizeBase: 34
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}

--- a/Assets/_Game/UI/NPCDebugCanvas.prefab.meta
+++ b/Assets/_Game/UI/NPCDebugCanvas.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d4b577630be655049bbaf5ac70b94f51
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Game/UI/NPCDebugHUD.cs
+++ b/Assets/_Game/UI/NPCDebugHUD.cs
@@ -1,0 +1,60 @@
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+public class NPCDebugHUD : MonoBehaviour
+{
+    public BaseNPC NPC;
+
+    [Header("Debug Health Slider")]
+    private Transform _playerTransform;
+    public Slider HealthSlider;
+    public TextMeshProUGUI DistanceText;
+
+
+    private void Start()
+    {
+        _playerTransform = GameObject.FindGameObjectWithTag("Player").transform;
+        if (_playerTransform == null)
+        {
+            Debug.LogError("Player transform not found in the scene.");
+            return;
+        }
+
+        if (NPC == null)
+        {
+            Debug.LogError("NPC was null. Assign it in the inspector.");
+            return;
+        }
+
+        SetUpHealthSlider();
+    }
+
+    private void SetUpHealthSlider()
+    {
+        if (HealthSlider == null)
+        {
+            Debug.LogError("HealthSlider not assigned on NPC: " + name);
+            return;
+        }
+
+        HealthSlider.minValue = 0;
+        HealthSlider.maxValue = NPC.MaxHealth;
+        HealthSlider.value = NPC.Health;
+    }
+
+    private void LateUpdate()
+    {
+        if (HealthSlider != null && NPC != null)
+        {
+            HealthSlider.value = NPC.Health;
+        }
+
+        if (DistanceText != null)
+        {
+            float distance = Vector3.Distance(transform.position, _playerTransform.position);
+            DistanceText.text = $"{distance:F2} m";
+        }
+    }
+
+}

--- a/Assets/_Game/UI/NPCDebugHUD.cs.meta
+++ b/Assets/_Game/UI/NPCDebugHUD.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c9452cfa57cd6234c863bb57c0325fc6

--- a/Assets/_Game/UI/UILookAtCamera.cs
+++ b/Assets/_Game/UI/UILookAtCamera.cs
@@ -1,0 +1,22 @@
+using UnityEngine;
+
+public class UILookAtCamera : MonoBehaviour
+{
+    private Transform _transform;
+    private Camera _camera;
+
+    private void Awake()
+    {
+        _transform = transform;
+        _camera = Camera.main;
+    }
+
+    private void LateUpdate()
+    {
+        if (_transform != null && _camera != null)
+        {
+            _transform.rotation = _camera.transform.rotation;
+        }
+    }
+
+}

--- a/Assets/_Game/UI/UILookAtCamera.cs.meta
+++ b/Assets/_Game/UI/UILookAtCamera.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 09e33b8653ff0784a9feea12b4b9922f


### PR DESCRIPTION
Added a new NPC Debug prefab, which can be attached to any NPC.

So far I have added them to the SonNPC prefab and the EnemyNPC prefab.

Currently it contains a health bar and distance text.

https://github.com/user-attachments/assets/548378a6-ba02-470c-8fa2-dd045ba6f696

This HUD is isolated, the only assignment that has to be made is the NPC component

![npcdebughud](https://github.com/user-attachments/assets/e530e98a-fede-4fde-a80b-1811b68e7cd6)
