### PR TITLE
Improved Enemy Scan

### DIFF
--- a/Assets/Scripts/CommonNPC/EntityScanner.cs
+++ b/Assets/Scripts/CommonNPC/EntityScanner.cs
@@ -49,14 +49,18 @@ class EntityScanner
     {
         var eyePosition = SourceTransform.position + this.EyeOffset;
 
-        Vector3 boxCenter = SourceTransform.position + (SourceTransform.forward * (ViewDistance / 2f));
-        Vector3 boxHalfExtents = new Vector3(ViewDistance / 2f, 20.5f, ViewDistance / 2f);
+        //Vector3 boxCenter = SourceTransform.position + (SourceTransform.forward * (ViewDistance / 2f));
+        //Vector3 boxHalfExtents = new Vector3(ViewDistance / 2f, 20.5f, ViewDistance / 2f);
+        // Collider[] candidates = Physics.OverlapBox(boxCenter, boxHalfExtents, SourceTransform.rotation, _targetMask);
 
-        Collider[] candidates = Physics.OverlapBox(boxCenter, boxHalfExtents, SourceTransform.rotation, _targetMask);
+        // OverlapSphereNonAlloc will not allocate anything to memory, and a sphere is also quicker than a box
+        Collider[] candidates = new Collider[16]; // Adjust size as needed, e.x. 16 friendly NPCs in one space
+        int candidateCount = Physics.OverlapSphereNonAlloc(SourceTransform.position, ViewDistance / 2f, candidates, _targetMask);
 
         int count = 0;
         foreach (Collider target in candidates)
         {
+            if (target == null) continue;
             if (target.transform == SourceTransform) continue;
 
             float distanceToTarget = Vector3.Distance(eyePosition, target.transform.position);

--- a/Assets/Scripts/CommonNPC/EntityScanner.cs
+++ b/Assets/Scripts/CommonNPC/EntityScanner.cs
@@ -45,20 +45,20 @@ class EntityScanner
         set => _obstacleMask = value;
     }
 
+    private Collider[] _candidates = new Collider[16]; // Adjust size as needed, e.x. 16 friendly NPCs in one space
+
+
     public IEnumerable<Collider> doScan(int maxObjects = 0)
     {
         var eyePosition = SourceTransform.position + this.EyeOffset;
 
-        //Vector3 boxCenter = SourceTransform.position + (SourceTransform.forward * (ViewDistance / 2f));
-        //Vector3 boxHalfExtents = new Vector3(ViewDistance / 2f, 20.5f, ViewDistance / 2f);
-        // Collider[] candidates = Physics.OverlapBox(boxCenter, boxHalfExtents, SourceTransform.rotation, _targetMask);
+        _candidates = null; // Reset candidates array
 
         // OverlapSphereNonAlloc will not allocate anything to memory, and a sphere is also quicker than a box
-        Collider[] candidates = new Collider[16]; // Adjust size as needed, e.x. 16 friendly NPCs in one space
-        int candidateCount = Physics.OverlapSphereNonAlloc(SourceTransform.position, ViewDistance / 2f, candidates, _targetMask);
+        int candidateCount = Physics.OverlapSphereNonAlloc(SourceTransform.position, ViewDistance / 2f, _candidates, _targetMask);
 
         int count = 0;
-        foreach (Collider target in candidates)
+        foreach (Collider target in _candidates)
         {
             if (target == null) continue;
             if (target.transform == SourceTransform) continue;

--- a/Assets/Scripts/CommonNPC/EntityScanner.cs
+++ b/Assets/Scripts/CommonNPC/EntityScanner.cs
@@ -1,5 +1,6 @@
 using UnityEngine;
 using System.Collections.Generic;
+using System;
 
 class EntityScanner
 {
@@ -52,7 +53,7 @@ class EntityScanner
     {
         var eyePosition = SourceTransform.position + this.EyeOffset;
 
-        _candidates = null; // Reset candidates array
+        Array.Clear(_candidates, 0, _candidates.Length); // Reset candidates array
 
         // OverlapSphereNonAlloc will not allocate anything to memory, and a sphere is also quicker than a box
         int candidateCount = Physics.OverlapSphereNonAlloc(SourceTransform.position, ViewDistance / 2f, _candidates, _targetMask);


### PR DESCRIPTION
## Summary
Not requesting that this merges right here and now as I know you're still working in this area. However, I believe my changes are worth looking at and implementing.
- Now use Physics.OverlapSphereNonAlloc, which has no memory impact, and for something as common as NPC scanning, performance does come into play here. (main benefit of this change)
- I have kept the max allocation to 16 collider detections, we use the Player and FriendlyNPC layermask so this will only fill up if we have 14 more friendly NPCs within a detection radius. We can just up this number if we plan on having more than 14 children following the parent 😄 

We are now doing the sphere (left) instead of the square (right)
![detection](https://github.com/user-attachments/assets/7326efd6-16e3-42ba-b997-a665e5df1ce7)

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/DogFingerStudios/Home-Prototype001/blob/master/CONTRIBUTING.md) file.
- [x] I agree that my contribution will become part of a commercial project and I claim no rights or compensation.
- [x] I certify that this is my own work or I have full rights to submit it.
