### PR TITLE
Fixed the bug where the bullets go through the building.

### DIFF
--- a/Assets/Scripts/EnemyNPCs/EnemyAttackState.cs
+++ b/Assets/Scripts/EnemyNPCs/EnemyAttackState.cs
@@ -14,7 +14,6 @@ public class EnemyAttackState : NPCState
     public float range = 50f;
     public float damage = 10f;
     public float defaultDamage = 10f;
-    public LayerMask targetMask = LayerMask.GetMask("Player", "FriendlyNPC");
 
     [Header("Audio")]
     [Tooltip("Audio clip to play when the gun is fired.")]
@@ -118,7 +117,7 @@ public class EnemyAttackState : NPCState
     void Shoot()
     {
         var direction = this.NPC!.target.position - _firePoint.position;
-        if (Physics.Raycast(_firePoint.position, direction, out RaycastHit hit, range, targetMask))
+        if (Physics.Raycast(_firePoint.position, direction, out RaycastHit hit, range))
         {
             this.NPC!.StartCoroutine(FireRayEffect(hit.point));
 


### PR DESCRIPTION
## Summary
There was a bug where the bullet could travel through the building colliders.
I simply removed the LayerMask and now the bullet raycasts are stopped by all colliders.

## Checklist
- [X] I have read the [CONTRIBUTING.md](https://github.com/DogFingerStudios/Home-Prototype001/blob/master/CONTRIBUTING.md) file.
- [X] I agree that my contribution will become part of a commercial project and I claim no rights or compensation.
- [X] I certify that this is my own work or I have full rights to submit it.
