### PR TITLE
📜 Adding the equipped item to the Inventory Dialog;

### DIFF
--- a/Assets/Items/InventoryUI.cs
+++ b/Assets/Items/InventoryUI.cs
@@ -92,8 +92,7 @@ public class InventoryUI : MonoBehaviour
 
     public void ShowInventory(CharacterEntity entity)
     {
-        _inputState = InputManager.Instance.PushState();
-        InputManager.Instance.SetState(false, CursorLockMode.None, true);
+        _inputState = InputManager.Instance.SetState(false, CursorLockMode.None, true);
 
         foreach (GameObject item in _itemObjects)
         {

--- a/Assets/Items/InventoryUI.cs
+++ b/Assets/Items/InventoryUI.cs
@@ -9,6 +9,7 @@ using Toggle = UnityEngine.UI.Toggle;
 using Image = UnityEngine.UI.Image;
 using static UnityEngine.GraphicsBuffer;
 using System.Linq;
+using System.Runtime.CompilerServices;
 
 // This script is attached to the Inventory UI dialog prefab. 
 public class InventoryUI : MonoBehaviour
@@ -180,7 +181,19 @@ public class InventoryUI : MonoBehaviour
                 var tag = itemobj.GetComponent<InventoryItemHelper>();
                 if (tag != null && tag.ItemEntity != null && _owner != null)
                 {
-                    _owner.SetEquippedItem(tag.ItemEntity);
+                    string msg;
+                    if (IsEquippedItemSelected())
+                    {
+                        _owner.AddItemToInventory(tag.ItemEntity);
+                        msg = $"Item '{tag.ItemEntity.ItemData!.ItemName}' unequipped.";
+                    }
+                    else
+                    {
+                        _owner.SetEquippedItem(tag.ItemEntity);
+                        msg = $"Item '{tag.ItemEntity.ItemData!.ItemName}' equipped.";
+                    }
+
+                    BottomTypewriter.Instance.Enqueue(msg);
                     CloseDialog();
                     return;
                 }
@@ -281,5 +294,36 @@ public class InventoryUI : MonoBehaviour
         _useButton.interactable = (_selectedCount == 1);
         _dropButton.interactable = (_selectedCount > 0);
         _transferButton.interactable = (_selectedCount > 0);
+
+        if (IsEquippedItemSelected())
+        {
+            var text = _equipButton.GetComponentInChildren<TMP_Text>();
+            text!.text = "UnEquip";
+        }
+        else
+        {
+            var text = _equipButton.GetComponentInChildren<TMP_Text>();
+            text.text = "Equip";
+        }
+    }
+
+    private bool IsEquippedItemSelected()
+    {
+        if (_selectedCount == 1 && _itemObjects.Count > 0)
+        {
+            GameObject itemobj = _itemObjects[0];
+            Toggle itemToggle = itemobj.GetComponentInChildren<Toggle>();
+
+            if (itemToggle != null && itemToggle.isOn)
+            {
+                var tag = itemobj.GetComponent<InventoryItemHelper>();
+                if (tag != null && tag.ItemEntity == _owner!.EquippedItem)
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 }

--- a/Assets/Items/InventoryUI.cs
+++ b/Assets/Items/InventoryUI.cs
@@ -251,7 +251,6 @@ public class InventoryUI : MonoBehaviour
             _owner!.RemoveItemFromInventory(itemToTransfer);
         }
 
-        CloseDialog();
         if (itemsToTransfer.Count == 1)
         {
             BottomTypewriter.Instance.Enqueue($"Transferred '{itemsToTransfer[0].ItemData!.ItemName}' to {targetName}");
@@ -260,6 +259,8 @@ public class InventoryUI : MonoBehaviour
         {
             BottomTypewriter.Instance.Enqueue($"Transferred {itemsToTransfer.Count} items to {targetName}");
         }
+
+        CloseDialog();
     }
 
     private void OnDropButtonClicked()

--- a/Assets/Items/InventoryUI.cs
+++ b/Assets/Items/InventoryUI.cs
@@ -264,7 +264,8 @@ public class InventoryUI : MonoBehaviour
 
     private void OnDropButtonClicked()
     {
-        if (_selectedCount != 1) return;
+        List<ItemEntity> droppedItems = new List<ItemEntity>();
+
         foreach (GameObject itemobj in _itemObjects)
         {
             Toggle itemToggle = itemobj.GetComponentInChildren<Toggle>();
@@ -274,11 +275,22 @@ public class InventoryUI : MonoBehaviour
                 if (tag != null && tag.ItemEntity != null && _owner != null)
                 {
                     _owner.DropItem(tag.ItemEntity);
-                    CloseDialog();
-                    return;
+                    droppedItems.Add(tag.ItemEntity);
                 }
             }
         }
+
+        if (droppedItems.Count == 1)
+        {
+            BottomTypewriter.Instance.Enqueue($"Dropped '{droppedItems[0].ItemData!.ItemName}'");
+        }
+        else
+        {
+            BottomTypewriter.Instance.Enqueue($"Dropped {droppedItems.Count} items");
+        }
+
+        CloseDialog();
+        return;
     }
 
     private void CloseDialog()

--- a/Assets/Items/InventoryUI.cs
+++ b/Assets/Items/InventoryUI.cs
@@ -100,9 +100,11 @@ public class InventoryUI : MonoBehaviour
         }
         _itemObjects.Clear();
 
-        foreach (ItemEntity item in entity.Inventory)
+        _owner = entity;
+
+        foreach (ItemEntity? item in entity.Inventory.Prepend(_owner!.EquippedItem))
         {
-            if (item.ItemData == null) continue;
+            if (item == null || item.ItemData == null) continue;
 
             GameObject newItem = Instantiate(_itemPrefab, _contentPanel);
             newItem.SetActive(true);
@@ -138,10 +140,18 @@ public class InventoryUI : MonoBehaviour
                 button.onClick.AddListener(() => OnItemClicked(newItem, item.ItemData.ItemName));
             }
 
+            if (item == _owner.EquippedItem)
+            {
+                var image = newItem.GetComponentInChildren<Image>();
+                if (image != null)
+                {
+                    image.color = new Color(0.8f, 0.8f, 1.0f, 1.0f);
+                }
+            }
+
             _itemObjects.Add(newItem);
         }
 
-        _owner = entity;
         _selectedCount = 0;
         _inventoryDlg.SetActive(true);
     }

--- a/Assets/Scenes/Game.unity
+++ b/Assets/Scenes/Game.unity
@@ -2419,6 +2419,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: InventoryDlg
       objectReference: {fileID: 0}
+    - target: {fileID: 2931101716355484645, guid: 2a405954f53c9634482128343354e0fa, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 4709357688665819350, guid: 2a405954f53c9634482128343354e0fa, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -2461,7 +2465,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5490736754747808725, guid: 2a405954f53c9634482128343354e0fa, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -0.000045776367
+      value: -0.00002670288
       objectReference: {fileID: 0}
     - target: {fileID: 5906806815940352113, guid: 2a405954f53c9634482128343354e0fa, type: 3}
       propertyPath: m_AnchorMax.x


### PR DESCRIPTION
## Summary
Previously there was no way to tell an NPC to drop (or do anything) with an equipped item. This PR adds the equipped item to the list of item's in the character's inventory dialog. This allows the player to tell the NPC to do various things with their equipped item. This also allows the player to do things (unequip, drop, etc.) with their own equipped item through the inventory dialog.

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/DogFingerStudios/Home-Prototype001/blob/master/CONTRIBUTING.md) file.
- [x] I agree that my contribution will become part of a commercial project and I claim no rights or compensation.
- [x] I certify that this is my own work or I have full rights to submit it.
