### PR TITLE
Add an error text display PR 2

### DIFF
--- a/Assets/_Game/Missions/Mission.cs
+++ b/Assets/_Game/Missions/Mission.cs
@@ -47,6 +47,11 @@ public class Mission
     {
         if (!StartMessage.Equals(string.Empty))
         {
+            //These should be removed once the error message TMP is added to the HUD.
+            GameObject canvasMain = GameObject.Find("Canvas_Main");
+            canvasMain.AddComponent<ErrorMessage>();
+            ErrorMessage.Instance.InitErrEssentials();
+            ErrorMessage.Instance.ShowError("Testing error message!");
             BottomTypewriter.Instance.Enqueue(StartMessage);
         }
         

--- a/Assets/_Game/Prefabs/HUD/ErrorMessage.cs
+++ b/Assets/_Game/Prefabs/HUD/ErrorMessage.cs
@@ -1,0 +1,104 @@
+using System.Collections;
+using TMPro;
+using UnityEngine;
+
+public sealed class ErrorMessage : MonoBehaviour
+{
+    [Header("References")]
+    [SerializeField] private CanvasGroup _canvasGroup;
+    [SerializeField] private TextMeshProUGUI _text;
+
+    [Header("Behavior")]
+    [SerializeField] private float _fadeSeconds = 0.12f;
+    [SerializeField] private float _displaySeconds = 5.0f;
+    [SerializeField] private bool _useUnscaledTime = true;
+
+    private Coroutine _routine;
+    private TextDisplayer _textDisplayer;
+
+    public static ErrorMessage Instance { get; private set; }
+
+    private void Awake()
+    {
+
+        if (Instance != null && Instance != this)
+        {
+            Destroy(gameObject);
+            return;
+        }
+
+        Instance = this;
+        _textDisplayer = new TextDisplayer();
+
+        if (_canvasGroup == null)
+        {
+            _canvasGroup = GetComponent<CanvasGroup>();
+            if (_canvasGroup == null)
+            {
+                _canvasGroup = gameObject.AddComponent<CanvasGroup>();
+            }
+        }
+
+        if (_text == null)
+        {
+            Debug.LogError("ErrorMessage: Text reference not assigned!");
+            return;
+        }
+
+        _text.alpha = 0f;
+        _canvasGroup.interactable = false;
+        _canvasGroup.blocksRaycasts = false;
+        _text.text = string.Empty;
+    }
+
+    public void ShowError(string message)
+    {
+
+        if (string.IsNullOrEmpty(message))
+        {
+            return;
+        }
+
+        if (_routine != null)
+        {
+            StopCoroutine(_routine);
+        }
+
+        _routine = StartCoroutine(ShowErrorRoutine(message));
+    }
+
+    //THIS FUNCTION IS TEMPORARY. Should be removed after the implementation of the text field into the Canvas_Main (prefab missing).
+    public void InitErrEssentials()
+    {
+        this._canvasGroup = GameObject.Find("BottomMessageRoot").GetComponent<CanvasGroup>();
+        GameObject btwText = GameObject.Find("MessageText");
+        GameObject copy = Instantiate(
+            btwText,
+            new Vector3(btwText.transform.position.x, btwText.transform.position.y - 100f, btwText.transform.position.z),
+            btwText.transform.rotation,
+            btwText.transform.parent
+        );
+        copy.name = "ErrorText";
+        this._text = copy.GetComponent<TextMeshProUGUI>();
+    }
+
+    private IEnumerator ShowErrorRoutine(string message)
+    {
+        _text.color = Color.red;
+        _text.text = message;
+
+        yield return _textDisplayer.FadeTo(1f, _fadeSeconds, _text, _useUnscaledTime);
+
+        float t = 0f;
+        while (t < _displaySeconds)
+        {
+            t += _textDisplayer.DeltaTime(_useUnscaledTime);
+            yield return null;
+        }
+
+        yield return _textDisplayer.FadeTo(0f, _fadeSeconds, _text, _useUnscaledTime);
+
+        _text.text = string.Empty;
+        _routine = null;
+    }
+}

--- a/Assets/_Game/Prefabs/HUD/ErrorMessage.cs.meta
+++ b/Assets/_Game/Prefabs/HUD/ErrorMessage.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6fac128a338d65747a2a5df099c851b6

--- a/Assets/_Game/Prefabs/HUD/TextDisplayer.cs
+++ b/Assets/_Game/Prefabs/HUD/TextDisplayer.cs
@@ -1,0 +1,32 @@
+using System.Collections;
+using TMPro;
+using UnityEngine;
+
+public class TextDisplayer : MonoBehaviour
+{
+    public IEnumerator FadeTo(float target, float seconds, TextMeshProUGUI _text, bool _useUnscaledTime)
+    {
+        if (seconds <= 0f)
+        {
+            _text.alpha = target;
+            yield break;
+        }
+
+        float start = _text.alpha;
+        float t = 0f;
+
+        while (t < seconds)
+        {
+            t += DeltaTime(_useUnscaledTime);
+            _text.alpha = Mathf.Lerp(start, target, t / seconds);
+            yield return null;
+        }
+
+        _text.alpha = target;
+    }
+
+    public float DeltaTime(bool _useUnscaledTime)
+    {
+        return _useUnscaledTime ? Time.unscaledDeltaTime : Time.deltaTime;
+    }
+}

--- a/Assets/_Game/Prefabs/HUD/TextDisplayer.cs.meta
+++ b/Assets/_Game/Prefabs/HUD/TextDisplayer.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2a6832dcfe80a394498b0ed8d2849765


### PR DESCRIPTION
## Summary
This change aims at resolving the Add an error text display https://github.com/DogFingerStudios/saintaveline/issues/123 issue. I added the second TMP text field into the Canvas, this time through the code, since the HUD canvas group wasn't a Prefab and I didn't wanted to mess with the Scene file. This resulted in few additional lines in Mission.cs and one standalone method in ErrorMessage - these should be removed once the HUD is made into a Prefab or the Scene file is available for edit (adding the TMP Text field manually). - I can add these changes as well, just tell me how exactly you envision it :-). 
 I created a standalone script Error Message for the error message display logic that controls the added text field and works independently from BottomTypewriter, but uses few methods from BottomTypewriter class, so I added new class called TextDisplayer, into which I've stored those overlapping methods, to prevent code duplication. I edited the FadeTo method because it was fading the entire Canvas and thus the error message, which is also a child of the Canvas, couldn't work properly, so instead of fading the Canvas object, the method is now fading the TMP Text objects itself respectfully. Also there is a testing method called in the Mission class, where a ShowError method is called to showcase its functionality.

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/DogFingerStudios/Home-Prototype001/blob/master/CONTRIBUTING.md) file.
- [x] I agree that my contribution will become part of a commercial project and I claim no rights or compensation.
- [x] I certify that this is my own work or I have full rights to submit it.
