### PR TITLE
fix: Restore player shooting broken by e638f133

### DIFF
--- a/Assets/_Game/Items/Pistol1Entity.cs
+++ b/Assets/_Game/Items/Pistol1Entity.cs
@@ -13,7 +13,6 @@ public class Pistol1Entity : ItemEntity
     private Coroutine? _attackCoroutine;
     private PistolItemData? _pistolItemData;
     private AudioSource? _audioSource;
-    private Camera? _mainCamera;
     private LineRenderer _lineRenderer;
     private Transform? _firePoint;
     private bool _canFire = true;
@@ -41,7 +40,6 @@ public class Pistol1Entity : ItemEntity
         }
 
         _audioSource = Instantiate(_pistolItemData!.AudioSourcePrefab);
-        _mainCamera = Camera.main;
 
         _firePoint = new GameObject("FirePoint").transform;
         _firePoint.SetParent(this.transform);
@@ -122,12 +120,12 @@ public class Pistol1Entity : ItemEntity
 
     void Shoot()
     {
-        Assert.IsNotNull(this.OwnerEntity, "Pistol1Entity.GetFireDirection: OwnerEntity is null.");
-        Assert.IsNotNull(this.OwnerEntity as BaseNPC, "Pistol1Entity.GetFireDirection: OwnerEntity is not a CharacterEntity.");
+        Assert.IsNotNull(this.OwnerEntity, "Pistol1Entity.Shoot: OwnerEntity is null.");
 
-        // purposely recalculate `npcOwner` since the target can change between shots
-        BaseNPC? npcOwner = this.OwnerEntity as BaseNPC;
-        Vector3 direction = npcOwner!.DirectionToTarget(true);
+        var owner = this.OwnerEntity as CharacterEntity;
+        Assert.IsNotNull(owner, "Pistol1Entity.Shoot: OwnerEntity is not a CharacterEntity.");
+
+        Vector3 direction = owner!.DirectionToTarget(true);
 
         if (Physics.Raycast(_firePoint!.position, direction, out RaycastHit hit, _pistolItemData!.FireRange))
         {

--- a/Assets/_Game/Scripts/CommonNPC/BaseNPC.cs
+++ b/Assets/_Game/Scripts/CommonNPC/BaseNPC.cs
@@ -151,7 +151,7 @@ public class BaseNPC : CharacterEntity, IHearingSensor
         // Debug.Log($"Object {objectName} heard a {stim.Kind} at {stim.Position}");
     }
 
-    public Vector3 DirectionToTarget(bool addFuzziness = false)
+    public override Vector3 DirectionToTarget(bool addFuzziness = false)
     {
         Assert.IsNotNull(_entityProfile, "BaseNPC.DirectionToTarget: EntityProfile is null.");
         if (Target == null) return Vector3.zero;

--- a/Assets/_Game/Scripts/CommonNPC/CharacterEntity.cs
+++ b/Assets/_Game/Scripts/CommonNPC/CharacterEntity.cs
@@ -259,4 +259,9 @@ public class CharacterEntity : GameEntity
         RaiseOnHealthChanged(Health);
         return Health;
     }
+
+    public virtual Vector3 DirectionToTarget(bool addFuzziness = false)
+    {
+        return transform.forward;
+    }
 }

--- a/Assets/_Game/Scripts/PlayerCharacter/PlayerStats.cs
+++ b/Assets/_Game/Scripts/PlayerCharacter/PlayerStats.cs
@@ -12,7 +12,12 @@ public class PlayerStats : CharacterEntity
     {
         if (Health <= 0)
         {
-            SceneManager.LoadScene("GameOver"); 
+            SceneManager.LoadScene("GameOver");
         }
+    }
+
+    public override Vector3 DirectionToTarget(bool addFuzziness = false)
+    {
+        return Camera.main.transform.forward;
     }
 }


### PR DESCRIPTION
## Summary

Commit `e638f133` broke player shooting. The change replaced camera-based `GetFireDirection()` with `BaseNPC.DirectionToTarget()`, but `Pistol1Entity.Shoot()` is used by **both players and NPCs**.

The player is a `CharacterEntity`, not a `BaseNPC`, so this cast fails:
```csharp
BaseNPC? npcOwner = this.OwnerEntity as BaseNPC;  // null for player
Vector3 direction = npcOwner!.DirectionToTarget(true);  // NullReferenceException
```

## Root Cause

Addy is amazing, but he is bogged down with many tasks because he is such an awesome programmer, and it's a tough job making sure people live up to his standards for architectural excellence. The irony of being schooled on polymorphism after shipping a breaking change that ignored class hierarchy is not lost on us. 😉

## The Fix

Implement `DirectionToTarget()` polymorphically across the CharacterEntity hierarchy:

| Class | Implementation |
|-------|----------------|
| `CharacterEntity` | Virtual base: `transform.forward` |
| `PlayerStats` | Override: `Camera.main.transform.forward` |
| `BaseNPC` | Override: Target-based aiming with fuzziness |

This lets `Pistol1Entity.Shoot()` use a single polymorphic call:
```csharp
var owner = this.OwnerEntity as CharacterEntity;
Vector3 direction = owner!.DirectionToTarget(true);
```

## Why This Approach

- Items shouldn't hold camera references
- Polymorphism over type-checking
- Each character type owns its aiming logic

## Class Hierarchy

```
CharacterEntity          ← virtual DirectionToTarget()
├── PlayerStats          ← override: camera forward
└── BaseNPC              ← override: target-based aiming
    ├── EnemyNPC
    └── FriendlyNPC
```

## Test Plan

- [ ] Equip pistol as player, left-click to shoot - fires toward camera direction
- [ ] NPCs with equipped weapons still aim at their targets

---

🤖 Generated with [Claude Code](https://claude.ai/code)