### PR TITLE
Making sure that Unity Unit Tests that don't pass make the build fail;

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -96,6 +96,43 @@ jobs:
           name: unity-test-results-${{ github.sha }}
           path: artifacts
 
+      - name: Fail job if any Unity tests failed (Linux)
+        shell: bash
+        run: |
+          echo "Checking Unity test result XML files..."
+
+          if [ ! -d "artifacts" ]; then
+            echo "No artifacts directory found. Failing to be safe."
+            exit 1
+          fi
+
+          xml_files=$(find artifacts -type f -name "*.xml")
+
+          if [ -z "$xml_files" ]; then
+            echo "No XML test files found under artifacts/. Failing to be safe."
+            exit 1
+          fi
+
+          for file in $xml_files; do
+            echo "Parsing $file"
+
+            # Check for failed attribute on test-run node
+            failed_count=$(grep -o 'failed="[0-9]*"' "$file" | head -n1 | grep -o '[0-9]*')
+            result_attr=$(grep -o 'result="Failed"' "$file")
+
+            if [ ! -z "$failed_count" ] && [ "$failed_count" -gt 0 ]; then
+              echo "Unity test-run reports $failed_count failed tests."
+              exit 1
+            fi
+
+            if [ ! -z "$result_attr" ]; then
+              echo "Unity test-case result=\"Failed\" found."
+              exit 1
+            fi
+          done
+
+          echo "All Unity test XML files indicate success."
+
       - name: Debug git status (optional)
         run: |
           git status --porcelain=v1

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-      # - dev/*
+      - dev/*
     paths:
       - .github/workflows/ubuntu.yml
       - Assets/**

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -96,42 +96,12 @@ jobs:
           name: unity-test-results-${{ github.sha }}
           path: artifacts
 
-      - name: Fail job if any Unity tests failed (Linux)
-        shell: bash
+      - name: Fail if any Unity test failed
         run: |
-          echo "Checking Unity test result XML files..."
-
-          if [ ! -d "artifacts" ]; then
-            echo "No artifacts directory found. Failing to be safe."
+          if grep -R 'result="Failed"' artifacts/*-results.xml; then
+            echo "Unity tests failed."
             exit 1
           fi
-
-          xml_files=$(find artifacts -type f -name "*.xml")
-
-          if [ -z "$xml_files" ]; then
-            echo "No XML test files found under artifacts/. Failing to be safe."
-            exit 1
-          fi
-
-          for file in $xml_files; do
-            echo "Parsing $file"
-
-            # Check for failed attribute on test-run node
-            failed_count=$(grep -o 'failed="[0-9]*"' "$file" | head -n1 | grep -o '[0-9]*')
-            result_attr=$(grep -o 'result="Failed"' "$file")
-
-            if [ ! -z "$failed_count" ] && [ "$failed_count" -gt 0 ]; then
-              echo "Unity test-run reports $failed_count failed tests."
-              exit 1
-            fi
-
-            if [ ! -z "$result_attr" ]; then
-              echo "Unity test-case result=\"Failed\" found."
-              exit 1
-            fi
-          done
-
-          echo "All Unity test XML files indicate success."
 
       - name: Debug git status (optional)
         run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -87,6 +87,46 @@ jobs:
           name: unity-test-results-${{ github.sha }}
           path: artifacts
 
+      - name: Fail job if any Unity tests failed
+        shell: pwsh
+        run: |
+          $xmlFiles = Get-ChildItem -Path "artifacts" -Recurse -Filter "*.xml" -ErrorAction SilentlyContinue
+          if (-not $xmlFiles)
+          {
+            Write-Host "No test XML files found under artifacts/. Failing to be safe."
+            exit 1
+          }
+
+          foreach ($file in $xmlFiles)
+          {
+            [xml]$doc = Get-Content $file.FullName
+
+            # NUnit root is typically <test-run ... failed="X" ... />
+            $testRun = $doc.SelectSingleNode("//test-run")
+            if ($null -ne $testRun)
+            {
+              $failed = [int]$testRun.GetAttribute("failed")
+              $result = $testRun.GetAttribute("result")
+              Write-Host "Parsed $($file.Name): result=$result failed=$failed"
+
+              if ($failed -gt 0 -or $result -eq "Failed")
+              {
+                Write-Host "Unity tests failed according to $($file.FullName)"
+                exit 1
+              }
+            }
+
+            # Fallback: if any <test-case result="Failed"> exists
+            $failedCases = $doc.SelectNodes("//test-case[@result='Failed']")
+            if ($failedCases -and $failedCases.Count -gt 0)
+            {
+              Write-Host "Found $($failedCases.Count) failed test-case nodes in $($file.FullName)"
+              exit 1
+            }
+          }
+
+          Write-Host "All Unity test result XML files indicate success."
+
       - name: Debug git status (optional)
         run: |
           git status --porcelain=v1

--- a/Assets/_Tests/_EditorTests/EditorTestScript.cs
+++ b/Assets/_Tests/_EditorTests/EditorTestScript.cs
@@ -16,6 +16,16 @@ public class EditorTestScript
         Assert.IsTrue(beggingForUnitTests);
     }
 
+    [Test]
+    public void ThisWillFail()
+    {
+        // AI: This test is intentionally designed to fail to demonstrate the testing framework's ability to catch failures.
+        int expectedValue = 42;
+        int actualValue = 24; // This value is incorrect on purpose
+
+        Assert.AreEqual(expectedValue, actualValue, "The actual value does not match the expected value, indicating a failure in the test.");
+    }
+
     // A UnityTest behaves like a coroutine in Play Mode. In Edit Mode you can use
     // `yield return null;` to skip a frame.
     [UnityTest]

--- a/Assets/_Tests/_EditorTests/EditorTestScript.cs
+++ b/Assets/_Tests/_EditorTests/EditorTestScript.cs
@@ -16,15 +16,15 @@ public class EditorTestScript
         Assert.IsTrue(beggingForUnitTests);
     }
 
-    // [Test]
-    // public void ThisWillFail()
-    // {
-    //     // AI: This test is intentionally designed to fail to demonstrate the testing framework's ability to catch failures.
-    //     int expectedValue = 42;
-    //     int actualValue = 24; // This value is incorrect on purpose
+    [Test]
+    public void ThisWillFail()
+    {
+        // AI: This test is intentionally designed to fail to demonstrate the testing framework's ability to catch failures.
+        int expectedValue = 42;
+        int actualValue = 24; // This value is incorrect on purpose
 
-    //     Assert.AreEqual(expectedValue, actualValue, "The actual value does not match the expected value, indicating a failure in the test.");
-    // }
+        Assert.AreEqual(expectedValue, actualValue, "The actual value does not match the expected value, indicating a failure in the test.");
+    }
 
     // A UnityTest behaves like a coroutine in Play Mode. In Edit Mode you can use
     // `yield return null;` to skip a frame.

--- a/Assets/_Tests/_EditorTests/EditorTestScript.cs
+++ b/Assets/_Tests/_EditorTests/EditorTestScript.cs
@@ -16,15 +16,15 @@ public class EditorTestScript
         Assert.IsTrue(beggingForUnitTests);
     }
 
-    [Test]
-    public void ThisWillFail()
-    {
-        // AI: This test is intentionally designed to fail to demonstrate the testing framework's ability to catch failures.
-        int expectedValue = 42;
-        int actualValue = 24; // This value is incorrect on purpose
+    // [Test]
+    // public void ThisWillFail()
+    // {
+    //     // AI: This test is intentionally designed to fail to demonstrate the testing framework's ability to catch failures.
+    //     int expectedValue = 42;
+    //     int actualValue = 24; // This value is incorrect on purpose
 
-        Assert.AreEqual(expectedValue, actualValue, "The actual value does not match the expected value, indicating a failure in the test.");
-    }
+    //     Assert.AreEqual(expectedValue, actualValue, "The actual value does not match the expected value, indicating a failure in the test.");
+    // }
 
     // A UnityTest behaves like a coroutine in Play Mode. In Edit Mode you can use
     // `yield return null;` to skip a frame.


### PR DESCRIPTION
## Summary
When Unit Tests were setup, the intention was that a failed unit tests would make a build fail and would require fixing/changing/etc before the build could be merged. However, failed unit tests were only generating log messages of such failures and the builds still passed. 

This change is to make sure that builds will fail when a unit test fails.

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/DogFingerStudios/Home-Prototype001/blob/master/CONTRIBUTING.md) file.
- [x] I agree that my contribution will become part of a commercial project and I claim no rights or compensation.
- [x] I certify that this is my own work or I have full rights to submit it.
